### PR TITLE
Support for better visual logging

### DIFF
--- a/lib/checkpack.js
+++ b/lib/checkpack.js
@@ -2,6 +2,7 @@
 require('babel-polyfill');
 
 const path = require('path');
+const logger = require('./logger');
 
 const cli = require('yargs')
   .help('h')
@@ -40,14 +41,14 @@ const cli = require('yargs')
       if (argv.validate) {
         const validator = require('./cli/validator');
         try {
-          validator(data.file);
+          validator(compilerName, data.file);
         } catch (e) {
-          console.log(e);
+          logger.errorType(compilerName, 'validator', e);
           process.exit(1);
         }
       } else {
         const opn = require('opn');
-        console.log('Opening tmp file: ' + data.file);
+        logger.log(compilerName, `Opening file: ${data.file}`);
         opn('file://' + data.file, {wait: false});
       }
     } else {

--- a/lib/cli/compile.js
+++ b/lib/cli/compile.js
@@ -1,18 +1,18 @@
 const fs = require('fs');
+const logger = require('../logger');
 
 module.exports = async (compilerName, basename, entryPath, outputPath) => {
   if (!fs.existsSync(entryPath)) {
-    return console.error('Entry file does not exists: ' + entryPath);
+    return logger.error(compilerName, `Entry file does not exists: ${entryPath}`);
   }
 
   if (!fs.existsSync(outputPath)) {
-    return console.error('Output directory does not exists: ' + outputPath);
+    return logger.error(compilerName, `Output directory does not exists: ${outputPath}`);
   }
 
   const compiler = require('../compiler/' + compilerName + '.compiler.js');
 
   await compiler(entryPath, outputPath, basename);
 
-  const filename = basename + '.' + compilerName + '.js';
-  console.log(compilerName + ' built: ' + outputPath + '/' + filename);
+  logger.log(compilerName, `Built: ${outputPath}/${basename}.${compilerName}.js`);
 };

--- a/lib/cli/validator.js
+++ b/lib/cli/validator.js
@@ -1,5 +1,7 @@
-module.exports = async (path) => {
+module.exports = async (compilerName, path) => {
   const puppeteer = require('puppeteer');
+  const chalk = require('chalk');
+  const logger = require('../logger');
 
   try {
     const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
@@ -7,16 +9,17 @@ module.exports = async (path) => {
     const page = await browser.newPage();
 
     page.on('pageerror', (...args) => {
-      console.log('PAGE ERROR:', ...args);
+      logger.errorType(compilerName, 'runtime', ...args);
       process.exit(1);
     });
 
     await page.goto('file://' + path);
 
     browser.close();
-    console.log('successfully validated');
+
+    logger.success(compilerName, 'Successfully validated.\n');
   } catch (e) {
-    console.log(e);
+    logger.errorType(compilerName, 'validator', e);
     process.exit(1);
   }
 };

--- a/lib/compiler/browserify.compiler.js
+++ b/lib/compiler/browserify.compiler.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const logger = require('../logger');
 
 module.exports = async (entryPath, outputPath, basename) => {
   return new Promise((resolve, reject) => {
@@ -13,6 +14,11 @@ module.exports = async (entryPath, outputPath, basename) => {
     browserify.plugin('tsify', [
       'noImplicitAny'
     ]);
-    browserify.bundle().pipe(stream);
+    const bundle = browserify.bundle();
+    bundle.on('error', (e) => {
+      logger.errorType('browserify', 'compile', e.message);
+      process.exit(1);
+    });
+    bundle.pipe(stream);
   });
 };

--- a/lib/compiler/webpack.compiler.js
+++ b/lib/compiler/webpack.compiler.js
@@ -1,6 +1,8 @@
 module.exports = async (entryPath, outputPath, basename) => {
   const configurator = require('./webpack_configurator');
   const webpack = require('webpack');
+  const chalk = require('chalk');
+  const logger = require('../logger');
 
   const config = configurator(
     basename,
@@ -12,7 +14,7 @@ module.exports = async (entryPath, outputPath, basename) => {
 
   return new Promise((resolve, reject) => compiler.run((_, stats) => {
     if (stats && stats.compilation.errors.length > 0) {
-      console.log(stats.compilation.errors);
+      logger.errorType('webpack', 'compile', stats.compilation.errors);
 
       process.exit(1);
     }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,48 @@
+const chalk = require('chalk');
+
+module.exports = {
+  verbose: true,
+  silent: false,
+  log(compiler, ...args) {
+    if (this.silent) {
+      return;
+    }
+    if (this.verbose) {
+      console.log(
+        this._header(compiler),
+        chalk.gray(...args)
+      );
+    }
+  },
+  success(compiler, ...args) {
+    if (this.silent) {
+      return;
+    }
+    console.log(
+      this._header(compiler),
+      chalk.green(...args)
+    );
+  },
+  errorType(compiler, type, ...args) {
+    if (this.silent) {
+      return;
+    }
+    console.error(
+      this._header(compiler),
+      chalk.underline.bold.red(`${type.toUpperCase()} ERROR:`),
+      chalk.red(...args)
+    );
+  },
+  error(compiler, ...args) {
+    if (this.silent) {
+      return;
+    }
+    console.error(
+      this._header(compiler),
+      chalk.red(...args)
+    );
+  },
+  _header(compiler) {
+    return chalk.white(`[${compiler}]`)
+  }
+};

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "awesome-typescript-loader": "~3.2.3",
     "babel-polyfill": "~6.26.0",
     "browserify": "~14.4.0",
+    "chalk": "^2.1.0",
     "opn": "~5.1.0",
     "path": "~0.12.7",
     "puppeteer": "~0.10.1",


### PR DESCRIPTION
Create better visual logging with the use of **chalk**. This creates some standard format for output message. Message are now all prepended with name of the compiler, e.g., `[webpack]`. 

Adds a logger class to centralize the formatting of these logs. Also adds a silent/verbose to the logger, which could potentially be implemented with a commandline flag in yargs.

### Runtime Error
![screen shot 2017-09-13 at 4 41 31 pm](https://user-images.githubusercontent.com/864393/30399683-8908214c-98a2-11e7-9666-ddc2a4f4f1cd.png)

### Success
![screen shot 2017-09-13 at 4 41 51 pm](https://user-images.githubusercontent.com/864393/30399681-890201ea-98a2-11e7-9b68-e28a06a248df.png)

### Compile Error
![screen shot 2017-09-13 at 4 42 28 pm](https://user-images.githubusercontent.com/864393/30399682-8902555a-98a2-11e7-8ad9-c3d6e7a1ae3a.png)
